### PR TITLE
feat/page-rendering-methods

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  siteMetadata: {
+    title: 'Mr Minimum',
+    description: 'An absolutely minimal Gatsby starter'
+  }
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,11 +1,73 @@
 import React from 'react';
+import { graphql } from 'gatsby';
 
-const Page = () => {
+const Page = ({ data, serverData }) => {
+  const {
+    site: {
+      siteMetadata: { title, description }
+    }
+  } = data;
+
+  const { name, job_title, company } = serverData;
+
   return (
-    <>
-      <main>Index Page</main>
-    </>
+    <main
+      style={{
+        display: 'grid',
+        gridGap: '16px'
+      }}
+    >
+      <div
+        style={{
+          border: '1px solid red'
+        }}
+      >
+        <small>SSG = data</small>
+        <h1>{title}</h1>
+        <p>{description}</p>
+      </div>
+
+      <div
+        style={{
+          border: '1px solid blue'
+        }}
+      >
+        <small>SSR = serverData</small>
+        <h2>{name}</h2>
+        <p>{job_title}</p>
+        <p>{company}</p>
+      </div>
+    </main>
   );
 };
+
+export async function getServerData() {
+  const response = await fetch(
+    'https://paulieapi.gatsbyjs.io/api/get-test-data'
+  );
+
+  const {
+    data: { name, job_title, company }
+  } = await response.json();
+
+  return {
+    props: {
+      name: name,
+      job_title: job_title,
+      company: company
+    }
+  };
+}
+
+export const query = graphql`
+  {
+    site {
+      siteMetadata {
+        title
+        description
+      }
+    }
+  }
+`;
 
 export default Page;


### PR DESCRIPTION
# Description
An example PR for using both `SSG` **data** and `SSR` **serverData** on the same page (site uses Gatsby 4).

- SSG `data` is stored in `gatsby-config.js` and queried using GraphQL
- SSR `serverData` is "fetched" from a test endpoint exposed by my Gatsby Functions API called `get-test-data`
 
_More info about my API can be found here 👉 [https://paulieapi.gatsbyjs.io/](https://paulieapi.gatsbyjs.io/)_

**If you have any questions come find me on Twitter: [https://twitter.com/PaulieScanlon](https://twitter.com/PaulieScanlon)**


## Changes 
- add `site.siteMetadata` to `gatsby.config.js`
- query `SSG` **data** in `index.js`
- fetch `SSR` **serverData** in `index.js`

###  Demo Link
🚀 [https://build-7bf76e61-3644-46a2-9d50-bbb3e6a15683.gtsb.io/](https://build-7bf76e61-3644-46a2-9d50-bbb3e6a15683.gtsb.io/)
